### PR TITLE
pygments.rb also requires python2-pygments

### DIFF
--- a/config.pkg/pygments.rb.yaml
+++ b/config.pkg/pygments.rb.yaml
@@ -1,2 +1,3 @@
 dependencies:
   - python2
+  - python2-pygments


### PR DESCRIPTION
It should also be done for pygments.rb-0.5 (dependency of jekyll), not sure if another file is needed or not.
