### PR TITLE
jekyll: Add dependency on nodejs

### DIFF
--- a/config.pkg/jekyll.yaml
+++ b/config.pkg/jekyll.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - nodejs


### PR DESCRIPTION
I guess technically it might support other JS engines as well, as the official
requirement reads:
- NodeJS, or another JavaScript runtime (for CoffeeScript support).
