### PR TITLE
Add puppetlabs_spec_helper to whitelist

### DIFF
--- a/whitelist_packages
+++ b/whitelist_packages
@@ -74,6 +74,7 @@ papertrail
 pg
 pry
 puma
+puppetlabs_spec_helper
 pygments.rb
 rack
 rack-cache


### PR DESCRIPTION
Package gem (+dependencies) required for easy testing of Puppet modules.
