### PR TITLE
Add Tmuxinator to whitelist

### DIFF
--- a/whitelist_packages
+++ b/whitelist_packages
@@ -101,6 +101,7 @@ tarantool-record
 thin
 thor
 tilt
+tmuxinator
 treetop
 twitter
 tzinfo


### PR DESCRIPTION
Hi,
I added the Tmuxinator to the `whitelist_packages` file. There is no need for extra dependencies.

Thx!
Regards,
Guillaume
