### PR TITLE
Add templates subdir to fpm package

### DIFF
--- a/config.pkg/fpm.yaml
+++ b/config.pkg/fpm.yaml
@@ -1,0 +1,2 @@
+include:
+  - templates


### PR DESCRIPTION
The erb templates subdirectory is required for fpm to build most package types.