### PR TITLE
Include license metadata file for spdx-licenses

### DIFF
--- a/config.pkg/spdx-licenses.yaml
+++ b/config.pkg/spdx-licenses.yaml
@@ -1,0 +1,2 @@
+include:
+  - spdx.json


### PR DESCRIPTION
Without the license file, metadata-json-lint throws the error:

```
No such file or directory @ rb_sysopen - /usr/lib/ruby/gems/2.2.0/gems/spdx-licenses-1.0.0/spdx.json (Errno::ENOENT)
```