### PR TITLE
Restore an old patch to support building json-1.7 gem

### DIFF
--- a/config.pkg/json-1.7.patch
+++ b/config.pkg/json-1.7.patch
@@ -1,0 +1,13 @@
+diff --git a/ext/json/ext/fbuffer/fbuffer.h b/ext/json/ext/fbuffer/fbuffer.h
+index af74187..9524fb1 100644
+--- a/ext/json/ext/fbuffer/fbuffer.h
++++ b/ext/json/ext/fbuffer/fbuffer.h
+@@ -172,7 +172,7 @@ static FBuffer *fbuffer_dup(FBuffer *fb)
+ 
+ static VALUE fbuffer_to_s(FBuffer *fb)
+ {
+-    VALUE result = rb_str_new(FBUFFER_PAIR(fb));
++    VALUE result = rb_str_new(FBUFFER_PTR(fb), FBUFFER_LEN(fb));
+     fbuffer_free(fb);
+     FORCE_UTF8(result);
+     return result;


### PR DESCRIPTION
It does not build under ruby 2.2, because `rb_str_new` changed from a
function declaration to a macro (flori/json#229).

Dependency chain for json-1.7 gem: `chef-server` → `chef-solr` → `chef-10.30` → `json-1.7`

This only affects rebuilds, as the current package was created before the patch was removed.