### PR TITLE
Add `guard` gem to package whitelist

### DIFF
--- a/whitelist_packages
+++ b/whitelist_packages
@@ -54,6 +54,7 @@ github-linguist
 github-markup
 god
 gpgme
+guard
 hashie
 heroku
 hike


### PR DESCRIPTION
Guard is a command line tool to easily handle events on file system
modifications. http://guardgem.org

This also brings in the following gems:
 * `shellany` - Command output capturing
 * `notiffany` - Wrapper for notification libraries
 * `lumberjack` - Logging utility