### PR TITLE
Whitelist homesick

### DIFF
--- a/whitelist_packages
+++ b/whitelist_packages
@@ -60,6 +60,7 @@ heroku
 hike
 hiredis
 hoe
+homesick
 i18n
 ipaddress
 jbuilder


### PR DESCRIPTION
Homesick is a git-based dotfile manager.