### PR TITLE
Add kramdown-rfc2629 package.

### DIFF
--- a/whitelist_packages
+++ b/whitelist_packages
@@ -76,6 +76,7 @@ jquery-rails
 json
 knife-azure
 knife-ec2
+kramdown-rfc2629
 liquid
 log4r
 lotus-model


### PR DESCRIPTION
This package is useful for producing IETF-style RFC documents from
markdown sources.