### PR TITLE
Add config for kramdown-rfc2629 package.

### DIFF
--- a/config.pkg/kramdown-rfc2629.yaml
+++ b/config.pkg/kramdown-rfc2629.yaml
@@ -1,0 +1,2 @@
+include:
+ - data


### PR DESCRIPTION
Turns out kramdown-rfc2629 needs its data/ directory to work. This adds
a config file to include that in the package.