### PR TITLE
Remove bundler

### DIFF
--- a/whitelist_packages
+++ b/whitelist_packages
@@ -5,7 +5,6 @@ bcrypt
 blankslate
 bluecloth
 bropages
-bundler
 bunny
 byebug
 capifony


### PR DESCRIPTION
ruby-bundler is now available in [community], so there's no need to keep it around in [quarry].