### PR TITLE
Whitelist puppet and rspec-puppet-facts gems

### DIFF
--- a/whitelist_packages
+++ b/whitelist_packages
@@ -125,6 +125,7 @@ rmagick
 ronn
 rotp
 rspec
+rspec-puppet-facts
 rspec-rails
 rubocop
 ruby-debug-ide


### PR DESCRIPTION
Whitelist additional gems to support Puppet module testing.