### PR TITLE
Add gtk3 to whitelist

### DIFF
--- a/whitelist_packages
+++ b/whitelist_packages
@@ -62,6 +62,7 @@ github-markup
 god
 gollum
 gpgme
+gtk3
 guard
 hanami
 hanami-model


### PR DESCRIPTION
gtk3 (and its dependencies) contains all the gtk, glib and gobject bindings for ruby. I use the gem with success.