### PR TITLE
Updates rails to support RubyMine autocomplete

### DIFF
--- a/config.pkg/rails.yaml
+++ b/config.pkg/rails.yaml
@@ -14,3 +14,6 @@ optdepends:
   ruby-byebug: live debugger for rails apps
   ruby-web-console: Access an IRB console on exception pages
   ruby-spring: speeds up development by keeping your application running in the background
+
+include:
+  - README.md


### PR DESCRIPTION
RubyMine complains about not having the rails gem installed, if rails isn't in the gem folder.  As a work around I currently have to install rails to the local user. Since the only file in the rails folder is README.md it has to be included for rails to be properly detected by RubyMine.