### PR TITLE
jquery-rails installs jquerry files

### DIFF
--- a/config.pkg/jquery-rails.yaml
+++ b/config.pkg/jquery-rails.yaml
@@ -1,0 +1,2 @@
+include:
+  - vendor/assets/javascripts


### PR DESCRIPTION
jquery-rails needs the `vendor/assets/javascripts` path to find jquery as intended. I can always just soft link the folder used by jquery on the aur, but rails includes each major version of jquery with the gem.  If you're fine with including the vendor folder I'll just submit a pull request.

I'm guessing it would be
```yaml
include:
  - vendor/assets/javascripts/*
```

Closes #62 