### PR TITLE
adds exe folder for rake gem

### DIFF
--- a/config.pkg/rake.yaml
+++ b/config.pkg/rake.yaml
@@ -1,0 +1,2 @@
+include:
+  - exe


### PR DESCRIPTION
Adds exe folder for the rake gem.  I believe having that folder would solve errors such as these:

```
Error:[rake --tasks] /home/zerophase/RubymineProjects/advanced-activerecord-querying-belongs_to-associations/bin/rake:16:in `load': cannot load such file -- /usr/lib/ruby/gems/2.3.0/specifications/exe/rake (LoadError)
	from /home/zerophase/RubymineProjects/advanced-activerecord-querying-belongs_to-associations/bin/rake:16:in `<main>'
```

