### PR TITLE
Missing vendor directory in autoprefixer-rails gem

### DIFF
--- a/config.pkg/autoprefixer-rails.yml
+++ b/config.pkg/autoprefixer-rails.yml
@@ -1,0 +1,2 @@
+include:
+  - vendor


### PR DESCRIPTION
``` [bash]
[rabidlogic@box site.net]$ bundle exec jekyll build 
Configuration file: /home/rabidlogic/Development/site.net/_config.yml
            Source: /home/rabidlogic/Development/site.net
       Destination: /home/rabidlogic/Development/site.net/_site
      Generating... 
jekyll 2.5.3 | Error:  No such file or directory @ rb_sysopen - /usr/lib/ruby/gems/2.4.0/gems/autoprefixer-rails-6.6.1/vendor/autoprefixer.js
```
Looking in the gem directory, I saw that the lib directory was the only directory there. Copying in the vendor directory from a user_gem install resolved the issue. 

I'm assuming I can add a config for a gem that isn't explicitly listed in the whitelist. If not, then it will also have to be added there. 