### PR TITLE
Add github-markdown

### DIFF
--- a/whitelist_packages
+++ b/whitelist_packages
@@ -83,6 +83,7 @@ git
 github
 github_api
 github-linguist
+github-markdown
 github-markup
 god
 gollum


### PR DESCRIPTION
github-markdown is needed for gollum in order to render markdown-style tables