### PR TITLE
Add KBSecret gem

### DIFF
--- a/whitelist_packages
+++ b/whitelist_packages
@@ -124,6 +124,7 @@ jmespath
 jquery-rails
 jquery-ui-rails
 json
+kbsecret
 knife-azure
 knife-ec2
 kramdown-rfc2629


### PR DESCRIPTION
[KBSecret](https://github/kbsecret/kbsecret) is a secrets manager backed by Keybase and KBFS.

I'm not that familiar with the Arch Linux ecosystem and this is my first experience with quarry, so please let me know if this isn't correct/anything additional is required!