### PR TITLE
Add config_curator to whitelist

### DIFF
--- a/whitelist_packages
+++ b/whitelist_packages
@@ -42,6 +42,7 @@ colored
 commonmarker
 compass
 configure-s3-website
+config_curator
 creole
 curb
 curses


### PR DESCRIPTION
I'd like to see this[1] package included.
Thanks!

[1] https://rubygems.org/gems/config_curator