### PR TITLE
Add guard-rake

### DIFF
--- a/config.pkg/guard-rake.yaml
+++ b/config.pkg/guard-rake.yaml
@@ -1,0 +1,3 @@
+depends:
+  - guard
+  - rake

--- a/whitelist_packages
+++ b/whitelist_packages
@@ -105,6 +105,7 @@ gollum
 gpgme
 gtk3
 guard
+guard-rake
 hanami
 hanami-model
 hashicorp-checkpoint


### PR DESCRIPTION
The `guard-rake` gem makes it easy to run Rake tasks through Guard.