### PR TITLE
add dory gem

### DIFF
--- a/whitelist_packages
+++ b/whitelist_packages
@@ -54,6 +54,7 @@ deep_merge
 delayed_job
 discourse-qunit-rails
 discourse_fastimage
+dory
 dotenv
 droxi
 em-handlersocket


### PR DESCRIPTION
gem used to have the same docker environment between macOS (dinghy) and linux
https://github.com/FreedomBen/dory