### PR TITLE
solargraph - add core doc for code completion

### DIFF
--- a/config.pkg/solargraph.yaml
+++ b/config.pkg/solargraph.yaml
@@ -1,0 +1,2 @@
+include:
+  - yardoc # core doc


### PR DESCRIPTION
https://github.com/castwide/solargraph

fix 
```bash
$ solagraph
Traceback (most recent call last):
	7: from /usr/bin/solargraph:23:in `<main>'
	6: from /usr/bin/solargraph:23:in `load'
	5: from /usr/lib/ruby/gems/2.6.0/gems/solargraph-0.32.5/bin/solargraph:3:in `<top (required)>'
	4: from /usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	3: from /usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	2: from /usr/lib/ruby/gems/2.6.0/gems/solargraph-0.32.5/lib/solargraph.rb:9:in `<top (required)>'
	1: from /usr/lib/ruby/gems/2.6.0/gems/solargraph-0.32.5/lib/solargraph.rb:40:in `<module:Solargraph>'
/usr/lib/ruby/gems/2.6.0/gems/solargraph-0.32.5/lib/solargraph.rb:40:in `realpath': No such file or directory @ realpath_rec - /usr/lib/ruby/gems/2.6.0/gems/solargraph-0.32.5/yardoc (Errno::ENOENT)
```