### PR TITLE
add docopt

### DIFF
--- a/whitelist_packages
+++ b/whitelist_packages
@@ -57,6 +57,7 @@ deep_merge
 delayed_job
 discourse-qunit-rails
 discourse_fastimage
+docopt
 dory
 dotenv
 droxi


### PR DESCRIPTION
It doesn't need a yaml config file.

This gem is very useful and used by a lot of project as it is an arg parser.