### PR TITLE
add rubocop-graphql

### DIFF
--- a/whitelist_packages
+++ b/whitelist_packages
@@ -252,6 +252,7 @@ rspec-rails
 rspotify
 rtlit
 rubocop
+rubocop-graphql
 rubocop-performance
 rubocop-rails
 rubocop-rspec


### PR DESCRIPTION
add linter rules for graphql-ruby https://github.com/DmitryTsepelev/rubocop-graphql