### PR TITLE
Add gem asciidoctor-diagram

### DIFF
--- a/whitelist_packages
+++ b/whitelist_packages
@@ -7,6 +7,7 @@ artifactory
 aruba
 asciidoctor
 asciidoctor-pdf
+asciidoctor-diagram
 aws-sdk
 aws-sdk-core
 aws-sdk-resources


### PR DESCRIPTION
An extension to AsciiDoctor useful to make diagrams.