### PR TITLE
Add mysql2 gem

### DIFF
--- a/whitelist_packages
+++ b/whitelist_packages
@@ -178,6 +178,7 @@ mongo
 mongo_ext
 multi_json
 mustache
+mysql2
 neovim
 net-ldap
 net-ssh


### PR DESCRIPTION
`mysql2` is a popular MySQL library

https://rubygems.org/gems/mysql2