### PR TITLE
Add just-the-docs gem

### DIFF
--- a/config.pkg/jekyll.yaml
+++ b/config.pkg/jekyll.yaml
@@ -3,5 +3,6 @@ optdepends:
   ruby-rdiscount: Alternative markdown parser
   ruby-jekyll-archives: Plugin to generate archive pages
   ruby-jekyll-feed: Plugin to generate an Atom feed
+  ruby-jekyll-include-cache: Plugin to cache the rendering of Liquid includes
   ruby-jekyll-seo-tag: Plugin to add meta tags for SEO
   ruby-jekyll-sitemap: Plugin to generate sitemap

--- a/config.pkg/just-the-docs.yaml
+++ b/config.pkg/just-the-docs.yaml
@@ -1,0 +1,7 @@
+include:
+  - Rakefile
+  - _includes
+  - _layouts
+  - _sass
+  - assets
+  - favicon.ico

--- a/whitelist_packages
+++ b/whitelist_packages
@@ -153,6 +153,7 @@ jekyll-compose
 jekyll-feed
 jekyll-gist
 jekyll-import
+jekyll-include-cache
 jekyll-paginate-v2
 jekyll-redirect-from
 jekyll-seo-tag
@@ -163,6 +164,7 @@ jose
 jquery-rails
 jquery-ui-rails
 json
+just-the-docs
 kbsecret
 kh2hc
 knife-azure


### PR DESCRIPTION
This adds [just-the-docs](https://rubygems.org/gems/just-the-docs) to `whitelist_packages`. The package contains numerous essential files outside of `bin` and `lib`. These are included in `config.pkg/just-the-docs.yaml`. Not sure if I did this correctly.

The dependency [jekyll-include-cache](https://rubygems.org/gems/jekyll-include-cache) is added as well. Since this is a Jekyll plugin, I chose to add it to the list of optional dependecies of `ruby-jekyll` with the description taken from the RubyGems site.